### PR TITLE
Support for URL path and query

### DIFF
--- a/request.go
+++ b/request.go
@@ -16,6 +16,8 @@ type Request struct {
 	ContentLength int64 `json:"content_length"`
 	Body string	`json:"body"`
 	Method string `json:"method"`
+	Path string `json:"path"`
+	Query string `json:"query"`
 }
 
 
@@ -37,6 +39,8 @@ func MakeRequest(req *http.Request) *Request {
 
 	r.ContentLength = req.ContentLength
 	r.Method = req.Method
+	r.Path = req.URL.Path
+	r.Query = req.URL.RawQuery
 
 	body, _ := ioutil.ReadAll(req.Body)
 	r.Body = string(body)

--- a/server.go
+++ b/server.go
@@ -11,7 +11,7 @@ import(
 	"os"
 	"os/signal"
 
-	"github.com/darklynx/requesthub/templates"
+	"github.com/kyledayton/requesthub/templates"
 )
 
 var config *Config

--- a/server.go
+++ b/server.go
@@ -11,7 +11,7 @@ import(
 	"os"
 	"os/signal"
 
-	"github.com/kyledayton/requesthub/templates"
+	"github.com/darklynx/requesthub/templates"
 )
 
 var config *Config

--- a/templates/show_hub.html.go
+++ b/templates/show_hub.html.go
@@ -75,11 +75,18 @@ SHOW_HUB = `
           });
 
           var reqNum = +request + 1;
+          var reqPath = data[request].path;
+          if (data[request].query) {
+            reqPath += "?" + data[request].query;
+          }
 
           var reqHTML = '<div class="row"><div class="large-1 columns"><h3>' + reqNum + ' <small>[' + data[request].method + ']</small></h3>' + '</div><div class="large-11 columns">' +
-							'<div class="panel">URL Path: ' + data[request].path +
-							'<br>Query Params: ' + data[request].query + '</div>' +
-							'<ul class="accordion" data-accordion="req' + reqNum + '">' +
+                '<ul class="accordion" data-accordion="req' + reqNum + '">' +
+                '<li class="accordion-navigation">' +
+                  '<a href="#reqpath' + reqNum + '">Path</a>' +
+                  '<div id="reqpath' + reqNum + '" class="content">' +
+                  '<div class="panel"><pre>' + reqPath +
+                  '</pre></div></div></li>' +
                 '<li class="accordion-navigation">' +
                   '<a href="#reqhead' + reqNum + '">Headers</a>' +
                   '<div id="reqhead' + reqNum + '" class="content">' +

--- a/templates/show_hub.html.go
+++ b/templates/show_hub.html.go
@@ -77,7 +77,9 @@ SHOW_HUB = `
           var reqNum = +request + 1;
 
           var reqHTML = '<div class="row"><div class="large-1 columns"><h3>' + reqNum + ' <small>[' + data[request].method + ']</small></h3>' + '</div><div class="large-11 columns">' +
-              '<ul class="accordion" data-accordion="req' + reqNum + '">' +
+							'<div class="panel">URL Path: ' + data[request].path +
+							'<br>Query Params: ' + data[request].query + '</div>' +
+							'<ul class="accordion" data-accordion="req' + reqNum + '">' +
                 '<li class="accordion-navigation">' +
                   '<a href="#reqhead' + reqNum + '">Headers</a>' +
                   '<div id="reqhead' + reqNum + '" class="content">' +


### PR DESCRIPTION
Capture the URL's `path` and `query` parameters of each incoming request, and visualize them on the show hub page.
